### PR TITLE
dividing len by 4 causes an error

### DIFF
--- a/src/seq.rs
+++ b/src/seq.rs
@@ -536,7 +536,7 @@ fn read_vector_len(packet: &[u8], offset: &mut usize) -> TlResult<usize> {
 
     // Length cannot be greater than the rest of the packet.
     // However min item size is 4 bytes so we could reduce it four times
-    if unlikely((len + *offset) > packet.len() >> 2) {
+    if unlikely((len * 4 + *offset) > packet.len()) {
         Err(TlError::UnexpectedEof)
     } else {
         Ok(len)


### PR DESCRIPTION
Deserialization Vector at the end of the packet causes an error. To properly check that the remaining packet length is more than 4 bytes it's necessary to compare (len * 4 + offset) and packet.len instead of dividing packet.len by 4.