### PR TITLE
Fix enum variants flagged fields writing

### DIFF
--- a/proc/src/tl_write.rs
+++ b/proc/src/tl_write.rs
@@ -53,8 +53,11 @@ fn build_generics(container: &ast::Container) -> syn::Generics {
 
 fn build_enum(container: &ast::Container, variants: &[ast::Variant]) -> TokenStream {
     let build_field = |field: &ast::Field| match &field.member {
-        syn::Member::Named(member) => quote! { #member },
-        syn::Member::Unnamed(index) => quote::format_ident!("field_{}", index).to_token_stream(),
+        syn::Member::Named(member) => quote! { &#member },
+        syn::Member::Unnamed(index) => {
+            let member = quote::format_ident!("field_{}", index).to_token_stream();
+            quote! { &#member }
+        }
     };
 
     let max_size_hint = match &container.attrs.size_hint {

--- a/test_suite/tests/tl_write.rs
+++ b/test_suite/tests/tl_write.rs
@@ -101,6 +101,17 @@ mod tests {
     }
 
     #[derive(TlWrite)]
+    enum EnumWithFlags {
+        Named {
+            #[tl(flags)]
+            flags: (),
+            #[tl(flags_bit = 0)]
+            value_1: Option<u32>,
+        },
+        Unnamed(#[tl(flags)] (), #[tl(flags_bit = 0)] Option<u32>),
+    }
+
+    #[derive(TlWrite)]
     struct StructWithMultipleFlags {
         #[tl(flags, default_flags = 0x40000000)]
         flags: (),


### PR DESCRIPTION
Fixes a error when using flags in enums:
```rust
#[derive(TlWrite)]
enum EnumWithFlags {
    Named {
        #[tl(flags)]
        flags: (),
        #[tl(flags_bit = 0)]
        value_1: Option<u32>,
    },
    Unnamed(#[tl(flags)] (), #[tl(flags_bit = 0)] Option<u32>)
}
```

```
error[E0614]: type `bool` cannot be dereferenced
   --> test_suite\tests\tl_write.rs:103:14
    |
103 |     #[derive(TlWrite)]
    |              ^^^^^^^
    |
    = note: this error originates in the derive macro `TlWrite` (in Nightly builds, run with -Z macro-backtrace for more info)
```