### PR TITLE
proper setup tl-scheme version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ sha2 = { version = "0.10", optional = true }
 smallvec = { version = "1.7", features = ["union", "const_generics"] }
 thiserror = "1.0.64"
 
-tl-proto-proc = { version = "=0.4.7", path = "proc", optional = true }
+tl-proto-proc = { version = "=0.4.8", path = "proc", optional = true }
 
 [features]
 default = ["derive", "bytes", "hash"]

--- a/proc/Cargo.toml
+++ b/proc/Cargo.toml
@@ -3,7 +3,7 @@ name = "tl-proto-proc"
 description = "A collection of traits for working with TL serialization/deserialization"
 authors = ["Ivan Kalinin <i.kalinin@dexpa.io>"]
 repository = "https://github.com/broxus/tl-proto"
-version = "0.4.7"
+version = "0.4.8"
 edition = "2021"
 include = ["src/**/*.rs", "../README.md"]
 license = "MIT"
@@ -16,4 +16,4 @@ proc-macro2 = "1.0.87"
 quote = "1.0"
 rustc-hash = "1.1.0"
 syn = { version = "2.0", features = ["visit"] }
-tl-scheme = { version = "0.2.0", path = "../scheme" }
+tl-scheme = { version = "=0.2.0", path = "../scheme" }


### PR DESCRIPTION
Hi, we recently start getting an error during library compilation:

```
error[E0308]: mismatched types
   --> /Users/sild/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tl-proto-proc-0.4.7/src/scheme_loader.rs:109:36
    |
109 |                     self.all_ids = self.scheme.compute_all_ids();
    |                     ------------   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `HashMap<u32, (ConstructorKind, &Constructor<'_>), BuildHasherDefault<FxHasher>>`, found `HashMap<u32, (ConstructorKind, &Constructor<'_>), FxBuildHasher>`
    |                     |
    |                     expected due to the type of this binding
    |
    = note: expected struct `HashMap<_, (ConstructorKind, &'a Constructor<'s>), BuildHasherDefault<FxHasher>>`
               found struct `HashMap<_, (ConstructorKind, &Constructor<'_>), rustc_hash::FxBuildHasher>`
```

After some digging I found it's because `tl-proto-protoc` doesn't have pinned `tl-proto-scheme` dependency (just `version="a.b.c" doesn't mean pinning, see [this ref](https://github.com/rust-lang/cargo/issues/10235#issuecomment-1001821125))

And in further version of `tl-proto-scheme` rustc-hash dependency version was upgraded `1.1.0` -> `2.1.0`.

Frankly speaking I'm not sure if that patch is done properly according to you version schema, but after using patched version locally build works well.

If patch looks good, please publish new version asap